### PR TITLE
[Feature] Allow file removing with a dedicated arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Usage: quiren [options] [dir]
 Options:
     -h, --help      Prints help information
     -r, --retry     Re-enters the editor after an error
+    -d, --delete    Delete files removed in the editor
 ```
 
 Examples:


### PR DESCRIPTION
According to #1, one can now delete files by using `quiren` with the `-d` command line argument.

It does not perform renaming since it is way too complex to track deleted files and renaming others at the same time.

Feel free to discard the PR if you don't feel like include this feature.